### PR TITLE
add design note for pouchdb plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ with enough detail to review the intent and direction of the feature.
  - [Exportable Subflow](designs/exportable-subflow/README.md)
  - [Node Timeout API](designs/timeout-api.md)
  - [Overwrite Values in settings.js](designs/overwrite-settings.md)
+ - [PouchDB Context store plugin](designs/pouchdb-context-plugin.md)
 
 #### In-progress
 

--- a/designs/pouchdb-context-plugin.md
+++ b/designs/pouchdb-context-plugin.md
@@ -117,7 +117,7 @@ Structure of data stored in PouchDB:
 
 - Data is saved in the JSON object format supported by PouchDB. The plugin does not convert JSON data to a string for storage.
 
-- Code example that references database data:
+Code example that references database data :
 ```javascript
 var pd = require('pouchdb');
 pd.plugin(require('pouchdb-adapter-node-websql'));
@@ -141,7 +141,7 @@ This allows you to back up the data stored in your local SQLite to a remote Couc
 
 - In an environment with multiple context stores, only contexts using the PouchDB plugin will be backed up.
 
-Code example of replication to remote database (CouchDB)ÅF
+Code example of replication to remote database(CouchDB) :
 ```javascript
 var pd = require('pouchdb');
 pd.plugin(require('pouchdb-adapter-node-websql'));
@@ -163,7 +163,7 @@ Reference: [PouchDB replication](https://pouchdb.com/api.html#replication)
 
 - Replication can also be filtered.You can also consider replicating a partial database (for example, only the global context part).
 
-Example of replication filtering in global context:
+Code example of replication filtering in global context :
 ```javascript
 db_source.replicate.to(db_target, {
   filter: function (doc) {

--- a/designs/pouchdb-context-plugin.md
+++ b/designs/pouchdb-context-plugin.md
@@ -9,11 +9,10 @@ The PouchDB Context store plugin holds context data in the PouchDB.
 ## Summary
 
 This plugin uses the PouchDB database for all context scopes.  
-PouchDB is an abstraction layer and the database to be used is selected by the adapter.  
-This plugin applies a Node SQLite adapter and saves the data in SQLite.
+PouchDB is an abstraction layer and the database to use can be selected by the adapter.
+In addition to the databases that PouchDB supports as standard, you can apply the NodeSQLite adapter to store your data in SQLite.
 
-pouchdb Adapters:
-https://pouchdb.com/adapters.html
+PouchDB Adapters: https://pouchdb.com/adapters.html
 
 ## Author
  - @KazuhiroIto
@@ -43,21 +42,21 @@ contextStorage: {
 
 | Options  | Description                                                                   |
 | -------- | ----------------------------------------------------------------------------- |
-| base     | the base directory to use.                     `default: "context"`           |
-| dir      | the directory to create the base directory in  `default: settings.userDir`    |
+| name     | Specifies the `name` argument for creating the PouchDB databse. You can specify the following.<br>- SQLite : Database storage file path<br>- LevelDB: Database storage folder path<br>- CouchDB: Database URL<br>`default(SQLite): settings.userDir/context/context.db` |
+| options  | Specifies the PouchDB database `options`. <br>Example<br>- SQLite : {adapter: 'websql'}<br>- LevelDB: {adapter: 'leveldb'} or {}<br>- CouchDB: {} <br>`default(SQLite): {adapter: 'websql'}`|
 
-The file name of the database is `"context.db"`.  
-Default database path:  `~/.node-red/context/context.db`
+Reference: [PouchDB Create a database options](https://pouchdb.com/api.html#create_database)
 
 ### Data Model
 
 - This plugin uses a PouchDB database for all context scope.
-- Use the Node SQLite adapter for the PouchDB adapter.
-Context Data is stored in SQLite3 using PouchDB API.
+- The NodeSQLite adapter is added to the PouchDB adapter. You can save the data in SQLite3.
+- You can also specify saving to a database (LevelDB, CouchDB) that PouchDB supports as standard.
 - This plugin saves a JSON object of keys and values in a document for each scope.
-  - The keys of `global context` will be id with `global` .Context data is stored in doc.data.
-  - The keys of `flow context` will be id with `<id of the flow>` .Context data is stored in doc.data.
-  - The keys of `node context` will be id with `<id of the node>` .Context data is stored in doc.data.
+  - The keys of `global context` will be id with `global` .
+  - The keys of `flow context` will be id with `<id of the flow>` .
+  - The keys of `node context` will be id with `<id of the node>` .
+  - Context data is stored in `doc.data` as a document for each scope.
 
 Structure of data stored in PouchDB:
 ```json
@@ -124,7 +123,7 @@ var pd = require('pouchdb');
 pd.plugin(require('pouchdb-adapter-node-websql'));
 var db;
 
-db = new pd( "/tmp/pouchdb/context/context.db", { adapter: 'websql' });
+db = new pd( "/home/user/.node-red/context/context.db", { adapter: 'websql' });
 db.allDocs({include_docs: true}, function(err, doc) {
    if (err) {
         return console.log(err);
@@ -135,6 +134,46 @@ db.allDocs({include_docs: true}, function(err, doc) {
 });
 ```
 
+### Database replication
+
+- The data in the context store can be replicated to other DBs using the PouchDB feature.
+This allows you to back up the data stored in your local SQLite to a remote CouchDB.This allows you to back up context data stored in your local SQLite to a remote CouchDB.
+
+- In an environment with multiple context stores, only contexts using the PouchDB plugin will be backed up.
+
+Code example of replication to remote database (CouchDB)ÅF
+```javascript
+var pd = require('pouchdb');
+pd.plugin(require('pouchdb-adapter-node-websql'));
+
+var source = "/home/user/.node-red/context/context.db";
+var target = "http://localhost:5984/couchdb_mycouchdb_1";
+
+var db_source = new pd(source, { adapter: 'websql' });
+var db_target = new pd(target);
+
+db_source.replicate.to(db_target)
+.on('complete', function () {
+        console.log ("Database replicated.");
+}).on('error', function (err) {
+        console.log(err);
+});
+```
+Reference: [PouchDB replication](https://pouchdb.com/api.html#replication)
+
+- Replication can also be filtered.You can also consider replicating a partial database (for example, only the global context part).
+
+Example of replication filtering in global context:
+```javascript
+db_source.replicate.to(db_target, {
+  filter: function (doc) {
+    return doc._id === 'global';
+}})
+```
+Reference: [PouchDB filtered replication](https://pouchdb.com/api.html#filtered-replication)
+
 ## History
 
   - 2021-03-03 - Initial Design Note
+  - 2021-06-15 - Added database replication and support standard plugin databases.
+  

--- a/designs/pouchdb-context-plugin.md
+++ b/designs/pouchdb-context-plugin.md
@@ -1,0 +1,140 @@
+---
+state: draft
+---
+
+# PouchDB Context store plugin
+
+The PouchDB Context store plugin holds context data in the PouchDB.
+
+## Summary
+
+This plugin uses the PouchDB database for all context scopes.  
+PouchDB is an abstraction layer and the database to be used is selected by the adapter.  
+This plugin applies a Node SQLite adapter and saves the data in SQLite.
+
+pouchdb Adapters:
+https://pouchdb.com/adapters.html
+
+## Author
+ - @KazuhiroIto
+
+## Details
+
+### Install
+
+1. Run the following command in your Node-RED user directory - typically `~/.node-red`
+
+    npm install git+https://github.com/node-red/node-red-context-pouchdb
+
+2. Add a configuration in settings.js:
+
+```javascript
+contextStorage: {
+    pouchdb: {
+        module: require("node-red-context-pouchdb"),
+        config: {
+            // see below options
+        }
+    }
+}
+```
+
+### Options
+
+| Options  | Description                                                                   |
+| -------- | ----------------------------------------------------------------------------- |
+| base     | the base directory to use.                     `default: "context"`           |
+| dir      | the directory to create the base directory in  `default: settings.userDir`    |
+
+The file name of the database is `"context.db"`.  
+Default database path:  `~/.node-red/context/context.db`
+
+### Data Model
+
+- This plugin uses a PouchDB database for all context scope.
+- Use the Node SQLite adapter for the PouchDB adapter.
+Context Data is stored in SQLite3 using PouchDB API.
+- This plugin saves a JSON object of keys and values in a document for each scope.
+  - The keys of `global context` will be id with `global` .Context data is stored in doc.data.
+  - The keys of `flow context` will be id with `<id of the flow>` .Context data is stored in doc.data.
+  - The keys of `node context` will be id with `<id of the node>` .Context data is stored in doc.data.
+
+Structure of data stored in PouchDB:
+```json
+{
+    "total_rows": 3,
+    "offset": 0,
+    "rows": [
+        {
+            "id": "2052fca8.312154:a77d79a4.d1a908",
+            "key": "2052fca8.312154:a77d79a4.d1a908",
+            "value": {
+                "rev": "6-55e0513ffba64a8b8efec1ba8e43c90f"
+            },
+            "doc": {
+                "data": {
+                    "NODE-KEY-1": "NODE-DATA-1",
+                    "NODE-KEY-2": "NODE-DATA-2"
+                },
+                "_id": "2052fca8.312154:a77d79a4.d1a908",
+                "_rev": "6-55e0513ffba64a8b8efec1ba8e43c90f"
+            }
+        },
+        {
+            "id": "a77d79a4.d1a908",
+            "key": "a77d79a4.d1a908",
+            "value": {
+                "rev": "61-2c2a457388db1c3859b79e4bb62e9375"
+            },
+            "doc": {
+                "data": {
+                    "FLOW-KEY-1": "FLOW-DATA-1",
+                    "FLOW-KEY-2": "FLOW-DATA-2",
+                },
+                "_id": "a77d79a4.d1a908",
+                "_rev": "61-2c2a457388db1c3859b79e4bb62e9375"
+            }
+        },
+        {
+            "id": "global",
+            "key": "global",
+            "value": {
+                "rev": "73-ee260387e51ae20132076ccc83957600"
+            },
+            "doc": {
+                "data": {
+                    "GLOBAL-KEY-1": "GLOBAL-DATA-1",
+                    "GLOBAL-KEY-2": "GLOBAL-DATA-2",
+                },
+                "_id": "global",
+                "_rev": "73-ee260387e51ae20132076ccc83957600"
+            }
+        }
+    ]
+}
+```
+
+### Data Structure
+
+- Data is saved in the JSON object format supported by PouchDB. The plugin does not convert JSON data to a string for storage.
+
+- Code example that references database data:
+```javascript
+var pd = require('pouchdb');
+pd.plugin(require('pouchdb-adapter-node-websql'));
+var db;
+
+db = new pd( "/tmp/pouchdb/context/context.db", { adapter: 'websql' });
+db.allDocs({include_docs: true}, function(err, doc) {
+   if (err) {
+        return console.log(err);
+   } else {
+        var data = JSON.stringify(doc,null,4);
+        console.log(data);
+   }
+});
+```
+
+## History
+
+  - 2021-03-03 - Initial Design Note


### PR DESCRIPTION
I have created a design note for PouchDB Context Store Pulugin.
PouchDB is an abstraction layer and the database to be used is selected by the adapter.
PouchDB Context Store Pulugin applies a Node SQLite adapter and saves the data in SQLite.
